### PR TITLE
Update provider

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,8 +21,12 @@
     "angular": "1.4.9",
     "angular-cookies": "1.4.9",
     "angular-dynamic-locale": "0.1.30",
+    "angular-i18n": "1.5.0",
     "angular-sanitize": "1.4.9",
-    "angular-translate": "2.9.0"
+    "angular-translate": "2.9.0",
+    "angular-translate-handler-log": "2.9.0",
+    "angular-translate-loader-static-files": "2.9.0",
+    "angular-translate-storage-local": "2.9.0"
   },
   "devDependencies": {
     "angular-mocks": "1.4.9"

--- a/src/providers/locale-provider.js
+++ b/src/providers/locale-provider.js
@@ -59,7 +59,6 @@
         }
 
         function setLocaleByDisplayName(localeDisplayName) {
-          console.log(localeDisplayName);
           _setLocale(_locales[_localeDisplayNames.indexOf(localeDisplayName)]);
         }
 

--- a/src/providers/locale-provider.js
+++ b/src/providers/locale-provider.js
@@ -3,8 +3,8 @@
 (function (angular) {
 
   angular
-      .module('km.i18n')
-      .provider('LocaleService', LocaleProvider);
+    .module('km.i18n')
+    .provider('LocaleService', LocaleProvider);
 
   LocaleProvider.$inject = [];
 
@@ -21,7 +21,7 @@
     var _localeDisplayNames = [];
     var _currentLocale;
 
-    _this.setSupportedLocales = function(localObj){
+    _this.setSupportedLocales = function (localObj) {
       _localesObj.locales = angular.extend(_localesObj.locales, localObj);
       _locales = Object.keys(_localesObj);
     };
@@ -33,32 +33,37 @@
       'tmhDynamicLocale',
       function ($rootScope, $log, $translate, tmhDynamicLocale) {
 
-        _currentLocale = $translate.use();
-        _locales = Object.keys(_localesObj.locales);
+        $translate.use('en_US')
+          .then(function (response) {
+            _currentLocale = response;
+            _locales = Object.keys(_localesObj.locales);
 
-        if (!_locales || _locales.length === 0) {
-          $log.error('There are no _LOCALES provided');
+            if (!_locales || _locales.length === 0) {
+              $log.error('There are no _LOCALES provided');
 
-        } else {
-          _locales.forEach(function (locale) {
-            _localeDisplayNames.push(_localesObj.locales[locale]);
+            } else {
+              angular.forEach(_localesObj.locales, function (locale) {
+                _localeDisplayNames.push(locale);
+              });
+
+              _updateLocale(_currentLocale);
+            }
           });
-          _updateLocale(_currentLocale);
-        }
 
-        function getSupportedLocales (){
+        function getSupportedLocales() {
           return _localesObj.locales;
         }
 
-        function getLocaleDisplayName () {
+        function getLocaleDisplayName() {
           return _localesObj.locales[_currentLocale];
         }
 
-        function setLocaleByDisplayName (localeDisplayName) {
+        function setLocaleByDisplayName(localeDisplayName) {
+          console.log(localeDisplayName);
           _setLocale(_locales[_localeDisplayNames.indexOf(localeDisplayName)]);
         }
 
-        function getLocalesDisplayNames () {
+        function getLocalesDisplayNames() {
           return _localeDisplayNames;
         }
 
@@ -77,10 +82,10 @@
         }
 
         function _updateLocale(locale) {
-          if(locale){
+          if (locale) {
 
-          document.documentElement.setAttribute('lang', locale);
-          tmhDynamicLocale.set(locale.toLowerCase().replace(/_/g, '-'));
+            document.documentElement.setAttribute('lang', locale);
+            tmhDynamicLocale.set(locale.toLowerCase().replace(/_/g, '-'));
           }
         }
 

--- a/src/providers/locale-provider.test.js
+++ b/src/providers/locale-provider.test.js
@@ -70,13 +70,11 @@ describe.only('Locale Service', function () {
 
     beforeEach(module(function ($provide) {
 
-      $provide.service('$translate', function () {
+      $provide.service('$translate', function ($q) {
         this.storage = angular.noop;
         this.storageKey = angular.noop;
         this.preferredLanguage = angular.noop;
-        this.use = function () {
-          return 'en_US';
-        };
+        this.use = sinon.stub().returns($q.resolve('en_US'));
 
         $provide.service('tmhDynamicLocale', function () {
           this.set = angular.noop;
@@ -129,6 +127,7 @@ describe.only('Locale Service', function () {
         });
 
         it('should return the locale display name', function () {
+          $rootScope.$apply();
           expect(LocaleService.getLocaleDisplayName()).to.equal(defaultLocales['en_US']);
         });
 
@@ -154,13 +153,15 @@ describe.only('Locale Service', function () {
         });
 
         it('should update the active locale when provided a valid locale name', function () {
+          $rootScope.$apply();
+
           LocaleService.setLocaleByDisplayName(customLocales.ru_RU);
 
           expect(LocaleService.getLocaleDisplayName()).to.equal(customLocales.ru_RU);
         });
 
         it('should utilize the $translate.use method to load and apply the locale changes', function () {
-          var spy = sinon.spy($translate, 'use');
+          var spy = $translate.use;
 
           LocaleService.setLocaleByDisplayName(customLocales['en_US']);
 
@@ -177,6 +178,7 @@ describe.only('Locale Service', function () {
         });
 
         it('should return an array of the supported locale display names', function () {
+          $rootScope.$apply();
           expect(LocaleService.getLocalesDisplayNames()).to.deep.equal(mockDisplayNames);
         });
 


### PR DESCRIPTION
The `$translate.use()` method returns a promise, which was misrepresented in the tests. Once this had been updated, a few tests needed modification.
